### PR TITLE
Make aggregate result stable. Fix wl_fixed_t encoding 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 
 dist/
+
+# TypeScript incremental build cache
+tsconfig.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ One major use case is to listen to some events until the server is done sending 
 ```js
   await display.load(path.join(thisDir, "protocol", "wlr_output_management_unstable_v1.xml"));
   let wlr_output = await display.bind("zwlr_output_manager_v1");
-  let {head: heads, done: serial} = await wlr_output.drain(() => once(wlr_output, "done"));
+  let {head: heads = [], done: [serial] = []} = await wlr_output.drain(() => once(wlr_output, "done"));
 ```
 
-Way better than manually wiring every event recursively. The `drain()` call collects all events until the `"done"` event fires, including `"done"` itself — so `serial` and `heads` are both available in the result.
+Way better than manually wiring every event recursively. The `drain()` call collects all events until the `"done"` event fires, including `"done"` itself — so `serial` and `heads` are both available in the result. Every event key is an **array** with one entry per emission (`heads` is one entry per `"head"` event, `done` is `[serial]`), so the shape is the same whether an event fired once or many times.
 
 ### compile a protocol file
 
@@ -157,8 +157,13 @@ Prefer passing a **factory function** so the `until` listener is registered *aft
 
 ```js
 const result = await itf.drain(() => once(itf, "done"));
-// result.done  — args from the "done" event
-// result.mode  — args from any "mode" events (array if fired multiple times)
+// Every event key is an array with one entry per emission (only `id` is scalar):
+//   no-arg event    -> [true, ...]
+//   single-arg event-> [value, ...]
+//   multi-arg event -> [[a, b], ...]
+//   child interface -> [nestedResult, ...]
+const [serial] = result.done;        // single "done" event
+for (const mode of result.mode ?? []) { /* one entry per "mode" event */ }
 ```
 
 Passing a bare promise also works when the promise is independent of this interface's events.

--- a/examples/wlr_output_management.js
+++ b/examples/wlr_output_management.js
@@ -18,8 +18,9 @@ open_display().then(async (display)=>{
   //*
   await display.load(path.join(thisDir, "protocol", "wlr_output_management_unstable_v1.xml"));
   let wlr_output = await display.bind("zwlr_output_manager_v1");
-  let {head: heads, done: serial} = await wlr_output.drain(() => once(wlr_output, "done"));
-  if(!Array.isArray(heads)) heads = (heads?[heads]: []);
+  // drain() returns one array per event: `heads` has an entry per "head" event,
+  // and the single "done" event carries the serial.
+  let {head: heads = [], done: [serial] = []} = await wlr_output.drain(() => once(wlr_output, "done"));
   console.log("HEAD : ", serial, JSON.stringify(heads, null, 2));
   
   let conf = await wlr_output.create_configuration(serial);

--- a/lib/args.test.ts
+++ b/lib/args.test.ts
@@ -45,19 +45,18 @@ describe("Buffer read/write", function(){
 
   });
 
-  ["LE", "BE"].forEach((en)=>{
-    it(`works in ${en == "LE"? "Little":"Big"} Endian systems`, function(){
-      let b = Buffer.alloc(4);
-      writeUInt(b, 1, 0, en as any);
-      expect(readUInt(b, 0, en as any)).to.equal(1);
+  // The helpers always use host byte order (both read and write), so a
+  // round-trip is consistent on any platform without an endianness argument.
+  it("round-trips integers and fixed-points in host byte order", function(){
+    let b = Buffer.alloc(4);
+    writeUInt(b, 1, 0);
+    expect(readUInt(b, 0)).to.equal(1);
 
-      
-      writeInt(b, -1, 0, en as any);
-      expect(readInt(b, 0, en as any)).to.equal(-1);
+    writeInt(b, -1, 0);
+    expect(readInt(b, 0)).to.equal(-1);
 
-      writeFixed(b, 1.5, 0, en as any);
-      expect(readFixed(b, 0, en as any)).to.equal(1.5);
-    });
+    writeFixed(b, 1.5, 0);
+    expect(readFixed(b, 0)).to.equal(1.5);
   });
 
 });

--- a/lib/args.test.ts
+++ b/lib/args.test.ts
@@ -362,6 +362,19 @@ describe("string encoding round-trips", function(){
     expect(out).to.equal(s);
     expect(out).to.have.length(4);
   });
+
+  // format_args uses allocUnsafe; the bytes between the NUL terminator and the
+  // 32-bit boundary must be explicitly zeroed so we never put uninitialised
+  // heap memory on the wire.
+  ["abcd", "héllo", "🚀 go", "a"].forEach((s)=>{
+    it(`zero-fills alignment padding after ${JSON.stringify(s)}`, function(){
+      const buf = format_args([s], strDef);
+      const strlen = Buffer.byteLength(s, "utf-8") + 1; // payload + NUL terminator
+      for(let i = 4 + strlen; i < buf.length; i++){
+        expect(buf[i], `padding byte at offset ${i} must be zero`).to.equal(0);
+      }
+    });
+  });
 });
 
 describe("writeArray() / readArray() round-trips", function(){

--- a/lib/args.test.ts
+++ b/lib/args.test.ts
@@ -7,6 +7,8 @@ import {
   readInt,
   get_args,
   writeInt,
+  readArray,
+  writeArray,
 } from "./args.js";
 import { expect } from "chai";
 import { ArgumentDefinition, ArgumentType } from "./definitions.js";
@@ -326,3 +328,65 @@ describe("get_args()", function(){
     ]);
   })
 })
+
+describe("string encoding round-trips", function(){
+  const strDef :ArgumentDefinition[] = [{ name: "s", type: "string" }];
+  [
+    "",            // empty: 0 bytes + NUL -> padded to 4
+    "a",
+    "abc",         // 3 + NUL = 4 (already aligned)
+    "abcd",        // 4 + NUL = 5 -> padded to 8
+    "héllo",       // 'é' is 2 UTF-8 bytes
+    "日本語",       // 3 chars x 3 bytes = 9 bytes
+    "🚀 go",        // rocket is a surrogate pair / 4 UTF-8 bytes
+  ].forEach((s)=>{
+    it(`round-trips ${JSON.stringify(s)}`, function(){
+      const buf = format_args([s], strDef);
+      expect(buf.length % 4, "encoded message must be 32-bit aligned").to.equal(0);
+      const [out] = get_args(buf, strDef);
+      expect(out).to.equal(s);
+    });
+
+    it(`prefixes the UTF-8 byte length (not char length) for ${JSON.stringify(s)}`, function(){
+      const buf = format_args([s], strDef);
+      // length prefix counts UTF-8 bytes plus the NUL terminator
+      expect(readUInt(buf, 0)).to.equal(Buffer.byteLength(s, "utf-8") + 1);
+    });
+  });
+
+  it("does not leak terminator/padding bytes into a decoded string that needs padding", function(){
+    // "abcd" is 4 bytes + NUL = 5, padded to 8 — three trailing bytes the decoder
+    // must not surface (format_args allocates the message body with allocUnsafe).
+    const s = "abcd";
+    const [out] = get_args(format_args([s], strDef), strDef);
+    expect(out).to.equal(s);
+    expect(out).to.have.length(4);
+  });
+});
+
+describe("writeArray() / readArray() round-trips", function(){
+  [0, 1, 2, 3, 4, 5, 7, 8, 9].forEach((len)=>{
+    it(`round-trips a ${len}-byte array and advances past the padding`, function(){
+      const data = new Uint8Array(len);
+      for(let i = 0; i < len; i++) data[i] = (i * 37) & 0xFF;
+      const padded = len + ((4 - (len % 4)) % 4);
+
+      const b = Buffer.alloc(4 + padded);
+      const writeEnd = writeArray(b, data, 0);
+      expect(writeEnd, "write offset includes length prefix + padded data").to.equal(4 + padded);
+
+      const [out, readEnd] = readArray(b, 0);
+      expect(Array.from(out)).to.deep.equal(Array.from(data));
+      expect(readEnd, "read offset matches write offset").to.equal(4 + padded);
+    });
+  });
+
+  it("reads a uint placed immediately after a non-aligned array at the correct offset", function(){
+    const data = new Uint8Array([0x11, 0x22, 0x33]); // 3 bytes -> 1 byte padding
+    const b = Buffer.alloc(4 + 4 + 4);               // len prefix + padded data + trailing uint
+    const off = writeArray(b, data, 0);
+    writeUInt(b, 0xCAFE, off);
+    const [, after] = readArray(b, 0);
+    expect(readUInt(b, after)).to.equal(0xCAFE);
+  });
+});

--- a/lib/args.test.ts
+++ b/lib/args.test.ts
@@ -20,10 +20,15 @@ describe("Buffer read/write", function(){
   describe("read / write fixed-points", function(){
     this.bail();
     [
-      //Those hex values and correspondances were verified through wayland queries dump 
-      [0x0100,      1],
-      [0x80000100, -1],
-      [0x0180,      1.5],
+      // wl_fixed_t is a two's-complement int32 holding value*256 (wayland-util.h:
+      // `typedef int32_t wl_fixed_t`, `wl_fixed_from_int(i) = i * 256`).
+      // The wire words below match the reference wl_fixed_from_double()/to_double().
+      [0x00000100,  1],
+      [0xFFFFFF00, -1],   // -256 two's complement (NOT sign-magnitude 0x80000100)
+      [0x00000180,  1.5],
+      [0xFFFFFE80, -1.5],
+      [0x00000080,  0.5],
+      [0xFFFFFF80, -0.5],
     ].forEach(([hex, value])=>{
       const b = Buffer.alloc(4);
       it(`read 0x${hex.toString(16)} as ${value}`, function(){

--- a/lib/args.ts
+++ b/lib/args.ts
@@ -160,6 +160,10 @@ export function format_args(args:any[], def:ArgumentDefinition[]) :Buffer{
         const strlen =  Buffer.byteLength(arg, "utf-8")+1;
         writeUInt(b, strlen, offset);
         b.write(arg+'\x00', offset + 4, "utf-8");
+        // Zero the alignment padding: the body is allocUnsafe'd, so the bytes
+        // between the NUL terminator and the 32-bit boundary would otherwise
+        // leak uninitialised heap memory onto the wire.
+        b.fill(0, offset + 4 + strlen, offset + argLengths[i]);
         offset += argLengths[i]; //account for 32bits padding when necessary
         break;
       case "array":

--- a/lib/args.ts
+++ b/lib/args.ts
@@ -28,22 +28,23 @@ export const readInt = (b :Buffer, offset :number, en:"LE"|"BE" = os_en)=> ((en 
 export const writeInt = (b :Buffer, value :number, offset :number, en:"LE"|"BE" = os_en) :number => ((en == "LE")? b.writeInt32LE : b.writeInt32BE).call(b, value, offset);
 
 /**
- * write a 24.8 fixed point value.
+ * Write a 24.8 signed fixed point value (wl_fixed_t).
+ *
+ * wl_fixed_t is a plain two's-complement `int32_t` holding `value * 256`
+ * (see wayland-util.h: `wl_fixed_from_int(i) = i * 256`). It is NOT a
+ * sign-magnitude number, so negative values must use the regular int32
+ * representation (e.g. -1.0 -> -256 -> 0xFFFFFF00 on the wire).
  */
 export function writeFixed(b :Buffer, value :number, offset :number, en:"LE"|"BE" = os_en) :number{
-  const fixed = Math.round(value * 256);
-  const sign = ((fixed < 0) ? 0x80000000 : 0);
-  return writeInt(b, sign | Math.abs(fixed), offset, en);
+  return writeInt(b, Math.round(value * 256), offset, en);
 }
 
 /**
- * Read a 24.8 fixed point value.
+ * Read a 24.8 signed fixed point value (wl_fixed_t).
+ * @see writeFixed
  */
 export function readFixed(b :Buffer, offset :number, en:"LE"|"BE" = os_en) :number{
-  const fixed = readInt(b, offset, en);
-  const sign = fixed & (1 << 31);
-  const num = fixed & ~(1 << 31);
-	return (sign? -1:1) * num / 256;
+  return readInt(b, offset, en) / 256;
 }
 
 /**

--- a/lib/args.ts
+++ b/lib/args.ts
@@ -3,29 +3,33 @@ import { endianness } from "os";
 import { ArgumentDefinition, wl_arg } from "./definitions.js";
 
 
-const os_en = endianness();
+// The Wayland wire protocol always uses the host's native byte order (client
+// and server share the machine over a unix socket). Resolve the right Buffer
+// methods once, at module load, rather than branching on every read/write.
+const LE = endianness() === "LE";
 
+type Reader = (b :Buffer, offset :number) => number;
+type Writer = (b :Buffer, value :number, offset :number) => number;
 
+/** read an uint32 in host byte order */
+export const readUInt :Reader = LE
+  ? (b, offset) => b.readUInt32LE(offset)
+  : (b, offset) => b.readUInt32BE(offset);
 
-/**
- * read an uint32 using native system's endianess
- */
-export const readUInt = (b :Buffer, offset :number, en:"LE"|"BE" = os_en) :number => ((en == "LE")? b.readUInt32LE : b.readUInt32BE).call(b, offset);
+/** write an uint32 in host byte order. @returns the offset past the written value */
+export const writeUInt :Writer = LE
+  ? (b, value, offset) => b.writeUInt32LE(value, offset)
+  : (b, value, offset) => b.writeUInt32BE(value, offset);
 
-/**
- * write an uint32 using native system's endianess
- */
-export const writeUInt = (b :Buffer, value :number, offset :number, en:"LE"|"BE" = os_en) :number => ((en == "LE")? b.writeUInt32LE : b.writeUInt32BE).call(b, value, offset);
+/** read an int32 in host byte order */
+export const readInt :Reader = LE
+  ? (b, offset) => b.readInt32LE(offset)
+  : (b, offset) => b.readInt32BE(offset);
 
-/**
- * read an int32 using native system's endianess
- */
-export const readInt = (b :Buffer, offset :number, en:"LE"|"BE" = os_en)=> ((en == "LE")? b.readInt32LE : b.readInt32BE).call(b, offset);
-
-/**
- * write an int32 using native system's endianess
- */
-export const writeInt = (b :Buffer, value :number, offset :number, en:"LE"|"BE" = os_en) :number => ((en == "LE")? b.writeInt32LE : b.writeInt32BE).call(b, value, offset);
+/** write an int32 in host byte order. @returns the offset past the written value */
+export const writeInt :Writer = LE
+  ? (b, value, offset) => b.writeInt32LE(value, offset)
+  : (b, value, offset) => b.writeInt32BE(value, offset);
 
 /**
  * Write a 24.8 signed fixed point value (wl_fixed_t).
@@ -35,16 +39,16 @@ export const writeInt = (b :Buffer, value :number, offset :number, en:"LE"|"BE" 
  * sign-magnitude number, so negative values must use the regular int32
  * representation (e.g. -1.0 -> -256 -> 0xFFFFFF00 on the wire).
  */
-export function writeFixed(b :Buffer, value :number, offset :number, en:"LE"|"BE" = os_en) :number{
-  return writeInt(b, Math.round(value * 256), offset, en);
+export function writeFixed(b :Buffer, value :number, offset :number) :number{
+  return writeInt(b, Math.round(value * 256), offset);
 }
 
 /**
  * Read a 24.8 signed fixed point value (wl_fixed_t).
  * @see writeFixed
  */
-export function readFixed(b :Buffer, offset :number, en:"LE"|"BE" = os_en) :number{
-  return readInt(b, offset, en) / 256;
+export function readFixed(b :Buffer, offset :number) :number{
+  return readInt(b, offset) / 256;
 }
 
 /**
@@ -54,9 +58,8 @@ export function readFixed(b :Buffer, offset :number, en:"LE"|"BE" = os_en) :numb
 export function readArray(
   b: Buffer,
   offset: number,
-  en: "LE" | "BE" = os_en,
 ): [data: Uint8Array, newOffset: number] {
-  const arrayLength = readUInt(b, offset, en);
+  const arrayLength = readUInt(b, offset);
   offset += 4;
   const arrayData = new Uint8Array(b.subarray(offset, offset + arrayLength));
   const padding = (4 - (arrayLength % 4)) % 4;
@@ -71,9 +74,8 @@ export function writeArray(
   b: Buffer,
   array: Uint8Array,
   offset: number,
-  en: "LE" | "BE" = os_en,
 ): number {
-  offset = writeUInt(b, array.length, offset, en);
+  offset = writeUInt(b, array.length, offset);
   b.set(array, offset);
   const padding = (4 - (array.length % 4)) % 4;
   if (padding > 0) {

--- a/lib/display.test.ts
+++ b/lib/display.test.ts
@@ -52,6 +52,40 @@ describe("class Wl_display", function(){
       expect(e).to.be.an("object");
       expect(e).to.have.property("invalid_object").that.is.a("number");
     });
+
+    it("throws a clear error for an unknown enum on a known interface", async function(){
+      const d = new Display(sMock);
+      await d.load("wayland");
+      expect(()=>d.getEnum("wl_display.nope"))
+        .to.throw(/No enum named "nope" in interface "wl_display"/);
+    });
+
+    it("throws for an unknown interface", async function(){
+      const d = new Display(sMock);
+      await d.load("wayland");
+      expect(()=>d.getEnum("wl_nonexistent.error"))
+        .to.throw(/No interface definition for wl_nonexistent/);
+    });
+
+    it("throws when the reference is not of the form <interface>.<enum>", async function(){
+      const d = new Display(sMock);
+      await d.load("wayland");
+      expect(()=>d.getEnum("wl_display")).to.throw(/expected the form/);
+    });
+  });
+
+  describe("registerInterface()", function(){
+    it("throws a clear error when the interface definition was never loaded", function(){
+      const d = new Display(sMock);
+      expect(()=>d.registerInterface(1, "wl_never_loaded"))
+        .to.throw(/Cannot register interface "wl_never_loaded": no protocol definition loaded/);
+    });
+
+    it("does not throw a cryptic 'reading map' error", function(){
+      const d = new Display(sMock);
+      expect(()=>d.registerInterface(1, "wl_never_loaded"))
+        .to.not.throw(/Cannot read properties of undefined/);
+    });
   });
 
   describe("request()", function(){

--- a/lib/display.ts
+++ b/lib/display.ts
@@ -283,6 +283,9 @@ export default class Display extends EventEmitter{
  */
   registerInterface<T extends Wl_interface = Wl_interface>(id :number, name :string, version?: number) :T{
     const def = typeof name ==="string"?this.#interfaces.get(name): name;
+    if(!def){
+      throw new Error(`Cannot register interface "${name}": no protocol definition loaded. Load the protocol that defines it (e.g. display.load("wayland")) before binding or creating it.`);
+    }
     const resolvedDef = version !== undefined ? {...def, version} : def;
     /* @ts-ignore */
     let itf = new Wl_interface(this, id, resolvedDef);
@@ -326,8 +329,10 @@ export default class Display extends EventEmitter{
 
   getEnum(name :string)  :EnumReduction{
     let [iName, eName] = name.split(".");
+    if(!eName) throw new Error(`Invalid enum reference "${name}": expected the form "<interface>.<enum>"`);
     let def = this.getDefinition(iName);
     let e = def.enums[eName];
+    if(!e) throw new Error(`No enum named "${eName}" in interface "${iName}". Known enums: ${Object.keys(def.enums).join(", ") || "(none)"}`);
     // JSON files generated before the EnumEntry format change stored enums as
     // plain arrays.  Accept both shapes for backward compatibility.
     const entries = Array.isArray(e) ? e : e.entries;

--- a/lib/display.ts
+++ b/lib/display.ts
@@ -181,7 +181,10 @@ export default class Display extends EventEmitter{
   protected onData = (d :Buffer)=>{
     d = this.#recv.length ? Buffer.concat([this.#recv, d]) : d;
     while(d.length >= 8){
-      const length = (readUInt(d, 4)>>16);
+      // Use an unsigned shift: the length lives in the high 16 bits of a u32,
+      // so messages of 32768..65535 bytes set bit 31 and a signed `>>` would
+      // yield a negative length, corrupting the framing loop.
+      const length = (readUInt(d, 4)>>>16);
       if(d.length < length) break;
       const id = readUInt(d, 0);
       const opcode = (readUInt(d, 4) &0xFFFF);
@@ -353,8 +356,11 @@ export default class Display extends EventEmitter{
     }
     debug("Wayland request: ", srcId, opcode, args, b2.length);
     writeUInt(b1, srcId, 0);
-    //16 most significant bits are the message length. 16 next bits are the message opcode
-    writeUInt(b1, (b1.length + b2.length) << 16 | opcode & 0xFFFF, 4);
+    //16 most significant bits are the message length. 16 next bits are the message opcode.
+    //Compose with multiplication/addition rather than `<<16`: a message of
+    //32768..65535 bytes would overflow the signed int32 that `<<` produces and
+    //make writeUInt throw (or write a corrupt length).
+    writeUInt(b1, (b1.length + b2.length) * 0x10000 + (opcode & 0xFFFF), 4);
     await this.write(Buffer.concat([b1, b2]));
   }
 

--- a/lib/interface.test.ts
+++ b/lib/interface.test.ts
@@ -360,7 +360,23 @@ describe("Wl_interface.aggregate()", function(){
     const end = itf.aggregate();
     itf.emit("done");
     const result = end();
-    expect(result.done).to.equal(true);
+    expect(result.done).to.deep.equal([true]);
+  });
+
+  it("records every occurrence of a repeated event as separate array entries", function(){
+    const def: InterfaceDefinition = {
+      ...emptyDef,
+      events: [{ name: "tick", description: "", summary: "", args: [
+        { name: "n", type: "uint", summary: "" },
+      ]}],
+    };
+    const itf = new Wl_interface(d, 3, def);
+    const end = itf.aggregate();
+    itf.emit("tick", 1);
+    itf.emit("tick", 2);
+    itf.emit("tick", 3);
+    const result = end();
+    expect(result.tick).to.deep.equal([1, 2, 3]);
   });
 
   it("records the value for single-arg events", function(){
@@ -374,7 +390,7 @@ describe("Wl_interface.aggregate()", function(){
     const end = itf.aggregate();
     itf.emit("size", 42);
     const result = end();
-    expect(result.size).to.equal(42);
+    expect(result.size).to.deep.equal([42]);
   });
 
   it("records array for multi-arg events", function(){
@@ -389,7 +405,8 @@ describe("Wl_interface.aggregate()", function(){
     const end = itf.aggregate();
     itf.emit("point", 3, 7);
     const result = end();
-    expect(result.point).to.deep.equal([3, 7]);
+    // one emission of a multi-arg event -> a single entry that is the args array
+    expect(result.point).to.deep.equal([[3, 7]]);
   });
 
   it("does not attach a listener for a version-filtered event", function(){
@@ -421,8 +438,8 @@ describe("Wl_interface.aggregate()", function(){
     itf.emit("ev_v1");
     itf.emit("ev_v1b");
     const result = end();
-    expect(result.ev_v1).to.equal(true);
-    expect(result.ev_v1b).to.equal(true);
+    expect(result.ev_v1).to.deep.equal([true]);
+    expect(result.ev_v1b).to.deep.equal([true]);
   });
 
   it("aggregates nested Wl_interface events", function(){
@@ -440,7 +457,8 @@ describe("Wl_interface.aggregate()", function(){
     const end = itf.aggregate();
     itf.emit("child", child);
     const result = end();
-    expect(result.child).to.be.an("object").with.property("id", 4);
+    expect(result.child).to.be.an("array").with.length(1);
+    expect((result.child as any[])[0]).to.be.an("object").with.property("id", 4);
   });
 });
 

--- a/lib/interface.ts
+++ b/lib/interface.ts
@@ -7,9 +7,20 @@ import { EventDefinition, RequestDefinition, EnumDefinition, InterfaceDefinition
 
 
 
+/**
+ * One recorded occurrence of an event:
+ *  - a no-arg event records `true`
+ *  - a single-arg event records the argument value
+ *  - a multi-arg event records the arguments as an array
+ *  - an interface-creation event records the child's nested {@link AggregateResult}
+ */
+type AggregateEntry = boolean | number | string | (number|string)[] | AggregateResult;
+
 interface AggregateResult{
+  /** This interface's object id. Scalar metadata — not an aggregated event. */
   id: number;
-  [e :string]: number|string|boolean|AggregateResult|number[]|string[]|AggregateResult[];
+  /** For each event that fired, an array with one {@link AggregateEntry} per emission. */
+  [event :string]: number | AggregateEntry[];
 }
 
 
@@ -164,6 +175,11 @@ export default class Wl_interface extends EventEmitter{
    * received by this interface over a period of time
    * into a single object.
    *
+   * Each event that fires is recorded under its own key as an **array** with one
+   * entry per emission (see {@link AggregateEntry}). The shape never depends on how
+   * many times an event fired, so a single occurrence is `[entry]`, not `entry`.
+   * Only `id` is a scalar.
+   *
    * **Prefer `drain()` for most use cases** — it handles cleanup automatically.
    *
    * The returned function also implements `Disposable`, so automatic cleanup is
@@ -205,9 +221,9 @@ export default class Wl_interface extends EventEmitter{
         this.off(name, listener);
       }
       cancellations.forEach((c)=>c());
-      for(let key in infos){
-        if((infos[key] as any).length == 1) infos[key] = (infos[key] as any)[0];
-      }
+      // Every event key is an array with one entry per emission. We intentionally
+      // do NOT unwrap single occurrences to a scalar: that made the result shape
+      // depend on how many times an event happened, which callers can't predict.
       return infos;
     };
     (end as any)[Symbol.dispose] = end;
@@ -222,6 +238,9 @@ export default class Wl_interface extends EventEmitter{
    * so that the `until` listener is registered *after* aggregation begins (no race window):
    * ```javascript
    *   const result = await itf.drain(() => once(itf, "done"));
+   *   // every event key is an array, one entry per emission:
+   *   const [serial] = result.done;   // single "done" event
+   *   for (const mode of result.mode ?? []) { ... }
    * ```
    * Passing a bare promise also works when the promise is independent of this interface's events (eg: a timeout or a global interface event).
    */

--- a/lib/makeTypes.test.ts
+++ b/lib/makeTypes.test.ts
@@ -1,0 +1,72 @@
+'use strict';
+import { expect } from "chai";
+import ts from "typescript";
+
+import makeTypes from "./makeTypes.js";
+import { InterfaceDefinition } from "./definitions.js";
+
+
+/** Parse generated source as a .d.ts and return any *syntax* errors. */
+function parseErrors(src: string): readonly ts.Diagnostic[] {
+  const sf = ts.createSourceFile("generated.d.ts", src, ts.ScriptTarget.Latest, true);
+  return (sf as any).parseDiagnostics as ts.Diagnostic[];
+}
+
+function def(overrides: Partial<InterfaceDefinition>): InterfaceDefinition {
+  return {
+    name: "wl_test", version: 1, description: "", summary: "",
+    requests: [], events: [], enums: {}, ...overrides,
+  };
+}
+
+describe("makeTypes()", function () {
+  it("produces syntactically valid TypeScript for benign input", function () {
+    const out = makeTypes([def({
+      summary: "a test interface",
+      description: "line one\nline two",
+      events: [{ name: "evt", description: "an event", summary: "fired", args: [] }],
+      requests: [{ name: "req", description: "a request", summary: "do it", args: [] }],
+      enums: { mode: { entries: [{ name: "fast", value: 1, summary: "go fast" }] } },
+    })]);
+    expect(parseErrors(out)).to.have.length(0);
+  });
+
+  it("escapes '*/' in a description so the JSDoc block is not closed early", function () {
+    const out = makeTypes([def({ description: "contains */ a comment closer" })]);
+    expect(out).to.not.include("contains */");      // raw closer is gone
+    expect(out).to.include("contains *\\/");         // escaped form present
+    expect(parseErrors(out)).to.have.length(0);
+  });
+
+  it("escapes '*/' in a summary", function () {
+    const out = makeTypes([def({ summary: "danger */ here" })]);
+    expect(out).to.not.include("danger */");
+    expect(parseErrors(out)).to.have.length(0);
+  });
+
+  it("emits enum summaries as valid string literals (quotes + newlines escaped)", function () {
+    const summary = 'has "quotes" and\na newline';
+    const out = makeTypes([def({
+      enums: { mode: { entries: [{ name: "a", value: 1, summary }] } },
+    })]);
+    expect(out).to.include(JSON.stringify(summary)); // properly escaped literal
+    expect(parseErrors(out)).to.have.length(0);
+  });
+
+  it("survives '*/' inside an enum entry summary", function () {
+    const out = makeTypes([def({
+      enums: { mode: { entries: [{ name: "a", value: 1, summary: "danger */ here" }] } },
+    })]);
+    expect(parseErrors(out)).to.have.length(0);
+  });
+
+  it("escapes a request argument summary containing '*/'", function () {
+    const out = makeTypes([def({
+      requests: [{
+        name: "req", description: "", summary: "",
+        args: [{ name: "x", type: "uint", summary: "weird */ summary" }],
+      }],
+    })]);
+    expect(parseErrors(out)).to.have.length(0);
+  });
+});

--- a/lib/makeTypes.ts
+++ b/lib/makeTypes.ts
@@ -23,7 +23,14 @@ function indent(str :string, spaces :number) :string{
 
 function comment(str :string|string[]){
   let lines = Array.isArray(str)?str.map(s=>s.replace(/\n$/, "")): str?.split("\n");
-  return lines? lines.map(l=>l.replace(/^\s+/, " ")).join("\n * "): "";
+  if(!lines) return "";
+  // Escape "*/" so a description/summary can't close the surrounding JSDoc block early.
+  return lines.map(l=>l.replace(/^\s+/, " ")).join("\n * ").replace(/\*\//g, "*\\/");
+}
+
+/** Render a one-line `@summary` JSDoc fragment, collapsing newlines and neutralising comment closers. */
+function summaryLine(summary :string|undefined){
+  return summary? `\n * @summary ${summary.replace(/\s*\n\s*/g, " ").replace(/\*\//g, "*\\/")}`: "";
 }
 
 
@@ -32,7 +39,7 @@ function nameToClass(name :string){
 }
 
 export const genInterface = ({name, version, description, summary, requests, events, enums} :InterfaceDefinition)=>`
-/**${summary? `\n * @summary ${summary}`:""}
+/**${summaryLine(summary)}
  * ${comment(description)}
  */
 export interface ${nameToClass(name)} extends Wl_interface{
@@ -58,7 +65,7 @@ const genEvent = ({name, description, summary, args} :EventDefinition)=>{
   }
   params.push(...args.map(a=> `${a.name}: wl_${a.type}`));
   return `
-/**${summary? `\n * @summary ${summary}`:""}
+/**${summaryLine(summary)}
  * ${comment(description)}
  */
 on(eventName: "${name}", listener: (${params.join(", ")})=>void): this;
@@ -77,9 +84,9 @@ const genRequest = ({name, description, summary, args} :RequestDefinition)=>{
     returnType = nameToClass(first_arg.interface);
   }
   return `
-/**${summary? `\n * @summary ${summary}`:""}
+/**${summaryLine(summary)}
  * ${comment(description)}
- * ${args.map(a=> `@param ${a.name} ${a.summary}`).join("\n * ")}
+ * ${args.map(a=> `@param ${a.name} ${comment(a.summary ?? "")}`).join("\n * ")}
  */
 ${name} (${args.map(a=> `${a.name}: wl_${a.type}`).join(", ")}) :Promise<${returnType}>;
 
@@ -88,13 +95,12 @@ ${name} (${args.map(a=> `${a.name}: wl_${a.type}`).join(", ")}) :Promise<${retur
 const genEnum = (name :string, en :EnumDefinition) :string =>`
 ${name}: [
   ${en.map(({name, value, summary})=>`
-  /**
-   *${summary? ` @summary ${summary}`:""}
+  /**${summaryLine(summary)}
    */
   {
     name: "${name}",
     value: ${value},
-    summary: "${summary?.replace(/\n/,"")}",
+    summary: ${JSON.stringify(summary ?? "")},
   },
 `).join("\n")}
 ]

--- a/lib/reliability.test.ts
+++ b/lib/reliability.test.ts
@@ -55,7 +55,9 @@ function makeMsg(objectId: number, opcode: number, body?: Buffer): Buffer {
   const b = body ?? Buffer.alloc(0);
   const header = Buffer.alloc(8);
   header.writeUInt32LE(objectId, 0);
-  header.writeUInt32LE(((8 + b.length) << 16) | (opcode & 0xFFFF), 4);
+  // length lives in the high 16 bits; compose via multiplication so lengths
+  // >= 32768 don't overflow the signed int32 that `<<16` would produce.
+  header.writeUInt32LE((8 + b.length) * 0x10000 + (opcode & 0xFFFF), 4);
   return Buffer.concat([header, b]);
 }
 
@@ -221,6 +223,67 @@ describe("onData: fragmented socket data is buffered and dispatched correctly", 
     d.feedData(msg2.subarray(3));
     expect(messages).to.have.length(2); // msg2 now complete
     expect(messages[1]).to.include({ id: 2, opcode: 1 });
+  });
+
+  // The message length sits in the high 16 bits of a u32. For a total length
+  // >= 32768 bytes, bit 31 of that word is set, so a signed `>> 16` would read
+  // a negative length and break framing. These cover the boundary and beyond.
+  ([32768, 40008, 65532] as const).forEach((total) => {
+    it(`frames a ${total}-byte message whose length sets the u32 sign bit`, function () {
+      const body = Buffer.alloc(total - 8).fill(0x5A);
+      body.writeUInt32LE(0xC0FFEE, 0);
+      d.feedData(makeMsg(7, 3, body));
+
+      expect(messages).to.have.length(1);
+      expect(messages[0]).to.include({ id: 7, opcode: 3 });
+      expect(messages[0].msg).to.have.length(total - 8, "body length must be decoded from an unsigned u32");
+      expect(messages[0].msg.readUInt32LE(0)).to.equal(0xC0FFEE);
+    });
+  });
+
+  it("frames a large message that arrives split across two chunks", function () {
+    const body = Buffer.alloc(50000).fill(0x5A);
+    const msg = makeMsg(8, 1, body);
+    d.feedData(msg.subarray(0, 20000));
+    expect(messages).to.have.length(0); // incomplete: must buffer, not mis-frame
+    d.feedData(msg.subarray(20000));
+    expect(messages).to.have.length(1);
+    expect(messages[0].msg).to.have.length(50000);
+  });
+});
+
+
+// ── Outgoing large request length encoding ────────────────────────────────
+
+describe("request(): encodes the length of a >= 32768-byte message correctly", function () {
+  /**
+   * The length is packed into the high 16 bits of a u32. Composing it with
+   * `<<16` overflows the signed int32 for messages of 32768..65535 bytes,
+   * which made writeUInt throw. request() must encode such a message and the
+   * header must round-trip through onData's framing.
+   */
+  it("sends a large request without throwing and with a recoverable length", async function () {
+    const d = new MockDisplay();
+    const def = {
+      name: "big", description: "", summary: "",
+      args: [{ name: "blob", type: "array", summary: "" }],
+    } as any;
+    // 4 (id) + 4 (header opcode/len) + 4 (array length prefix) + 40000 = 40012 bytes
+    const blob = new Uint8Array(40000).fill(0xAB);
+
+    await d.request(9, 2, def, blob);
+
+    expect(d.packets).to.have.length(1);
+    const packet = d.packets[0] as Buffer;
+    expect(packet).to.have.length(40012);
+
+    // Feed our own packet back through framing to confirm the header is valid.
+    const seen: { id: number; opcode: number; msg: Buffer }[] = [];
+    (d as any).onMessage = (id: number, opcode: number, msg: Buffer) => seen.push({ id, opcode, msg });
+    (d as any).onData(packet);
+    expect(seen).to.have.length(1);
+    expect(seen[0]).to.include({ id: 9, opcode: 2 });
+    expect(seen[0].msg).to.have.length(40004); // body = array prefix + 40000 payload
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wayland-client",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wayland-client",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "bin": {
         "convert-xml": "convert.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wayland-client",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "pure javascript client implementation of the wayland protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/protocol/wayland.d.ts
+++ b/protocol/wayland.d.ts
@@ -24,7 +24,7 @@ export interface Wl_display extends Wl_interface{
     error: [
       
       /**
-       * @summary server couldn't find object
+     * @summary server couldn't find object
        */
       {
         name: "invalid_object",
@@ -34,7 +34,7 @@ export interface Wl_display extends Wl_interface{
     
     
       /**
-       * @summary method doesn't exist on the specified interface or malformed request
+     * @summary method doesn't exist on the specified interface or malformed request
        */
       {
         name: "invalid_method",
@@ -44,7 +44,7 @@ export interface Wl_display extends Wl_interface{
     
     
       /**
-       * @summary server is out of memory
+     * @summary server is out of memory
        */
       {
         name: "no_memory",
@@ -54,7 +54,7 @@ export interface Wl_display extends Wl_interface{
     
     
       /**
-       * @summary implementation error in compositor
+     * @summary implementation error in compositor
        */
       {
         name: "implementation",
@@ -383,7 +383,7 @@ export interface Wl_shm extends Wl_interface{
     error: [
       
       /**
-       * @summary buffer format is not known
+     * @summary buffer format is not known
        */
       {
         name: "invalid_format",
@@ -393,7 +393,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary invalid size or stride during pool or buffer creation
+     * @summary invalid size or stride during pool or buffer creation
        */
       {
         name: "invalid_stride",
@@ -403,7 +403,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary mmapping the file descriptor failed
+     * @summary mmapping the file descriptor failed
        */
       {
         name: "invalid_fd",
@@ -417,7 +417,7 @@ export interface Wl_shm extends Wl_interface{
     format: [
       
       /**
-       * @summary 32-bit ARGB format, [31:0] A:R:G:B 8:8:8:8 little endian
+     * @summary 32-bit ARGB format, [31:0] A:R:G:B 8:8:8:8 little endian
        */
       {
         name: "argb8888",
@@ -427,7 +427,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit RGB format, [31:0] x:R:G:B 8:8:8:8 little endian
+     * @summary 32-bit RGB format, [31:0] x:R:G:B 8:8:8:8 little endian
        */
       {
         name: "xrgb8888",
@@ -437,7 +437,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 8-bit color index format, [7:0] C
+     * @summary 8-bit color index format, [7:0] C
        */
       {
         name: "c8",
@@ -447,7 +447,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 8-bit RGB format, [7:0] R:G:B 3:3:2
+     * @summary 8-bit RGB format, [7:0] R:G:B 3:3:2
        */
       {
         name: "rgb332",
@@ -457,7 +457,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 8-bit BGR format, [7:0] B:G:R 2:3:3
+     * @summary 8-bit BGR format, [7:0] B:G:R 2:3:3
        */
       {
         name: "bgr233",
@@ -467,7 +467,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit xRGB format, [15:0] x:R:G:B 4:4:4:4 little endian
+     * @summary 16-bit xRGB format, [15:0] x:R:G:B 4:4:4:4 little endian
        */
       {
         name: "xrgb4444",
@@ -477,7 +477,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit xBGR format, [15:0] x:B:G:R 4:4:4:4 little endian
+     * @summary 16-bit xBGR format, [15:0] x:B:G:R 4:4:4:4 little endian
        */
       {
         name: "xbgr4444",
@@ -487,7 +487,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit RGBx format, [15:0] R:G:B:x 4:4:4:4 little endian
+     * @summary 16-bit RGBx format, [15:0] R:G:B:x 4:4:4:4 little endian
        */
       {
         name: "rgbx4444",
@@ -497,7 +497,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit BGRx format, [15:0] B:G:R:x 4:4:4:4 little endian
+     * @summary 16-bit BGRx format, [15:0] B:G:R:x 4:4:4:4 little endian
        */
       {
         name: "bgrx4444",
@@ -507,7 +507,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit ARGB format, [15:0] A:R:G:B 4:4:4:4 little endian
+     * @summary 16-bit ARGB format, [15:0] A:R:G:B 4:4:4:4 little endian
        */
       {
         name: "argb4444",
@@ -517,7 +517,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit ABGR format, [15:0] A:B:G:R 4:4:4:4 little endian
+     * @summary 16-bit ABGR format, [15:0] A:B:G:R 4:4:4:4 little endian
        */
       {
         name: "abgr4444",
@@ -527,7 +527,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit RBGA format, [15:0] R:G:B:A 4:4:4:4 little endian
+     * @summary 16-bit RBGA format, [15:0] R:G:B:A 4:4:4:4 little endian
        */
       {
         name: "rgba4444",
@@ -537,7 +537,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit BGRA format, [15:0] B:G:R:A 4:4:4:4 little endian
+     * @summary 16-bit BGRA format, [15:0] B:G:R:A 4:4:4:4 little endian
        */
       {
         name: "bgra4444",
@@ -547,7 +547,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit xRGB format, [15:0] x:R:G:B 1:5:5:5 little endian
+     * @summary 16-bit xRGB format, [15:0] x:R:G:B 1:5:5:5 little endian
        */
       {
         name: "xrgb1555",
@@ -557,7 +557,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit xBGR 1555 format, [15:0] x:B:G:R 1:5:5:5 little endian
+     * @summary 16-bit xBGR 1555 format, [15:0] x:B:G:R 1:5:5:5 little endian
        */
       {
         name: "xbgr1555",
@@ -567,7 +567,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit RGBx 5551 format, [15:0] R:G:B:x 5:5:5:1 little endian
+     * @summary 16-bit RGBx 5551 format, [15:0] R:G:B:x 5:5:5:1 little endian
        */
       {
         name: "rgbx5551",
@@ -577,7 +577,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit BGRx 5551 format, [15:0] B:G:R:x 5:5:5:1 little endian
+     * @summary 16-bit BGRx 5551 format, [15:0] B:G:R:x 5:5:5:1 little endian
        */
       {
         name: "bgrx5551",
@@ -587,7 +587,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit ARGB 1555 format, [15:0] A:R:G:B 1:5:5:5 little endian
+     * @summary 16-bit ARGB 1555 format, [15:0] A:R:G:B 1:5:5:5 little endian
        */
       {
         name: "argb1555",
@@ -597,7 +597,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit ABGR 1555 format, [15:0] A:B:G:R 1:5:5:5 little endian
+     * @summary 16-bit ABGR 1555 format, [15:0] A:B:G:R 1:5:5:5 little endian
        */
       {
         name: "abgr1555",
@@ -607,7 +607,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit RGBA 5551 format, [15:0] R:G:B:A 5:5:5:1 little endian
+     * @summary 16-bit RGBA 5551 format, [15:0] R:G:B:A 5:5:5:1 little endian
        */
       {
         name: "rgba5551",
@@ -617,7 +617,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit BGRA 5551 format, [15:0] B:G:R:A 5:5:5:1 little endian
+     * @summary 16-bit BGRA 5551 format, [15:0] B:G:R:A 5:5:5:1 little endian
        */
       {
         name: "bgra5551",
@@ -627,7 +627,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit RGB 565 format, [15:0] R:G:B 5:6:5 little endian
+     * @summary 16-bit RGB 565 format, [15:0] R:G:B 5:6:5 little endian
        */
       {
         name: "rgb565",
@@ -637,7 +637,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 16-bit BGR 565 format, [15:0] B:G:R 5:6:5 little endian
+     * @summary 16-bit BGR 565 format, [15:0] B:G:R 5:6:5 little endian
        */
       {
         name: "bgr565",
@@ -647,7 +647,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 24-bit RGB format, [23:0] R:G:B little endian
+     * @summary 24-bit RGB format, [23:0] R:G:B little endian
        */
       {
         name: "rgb888",
@@ -657,7 +657,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 24-bit BGR format, [23:0] B:G:R little endian
+     * @summary 24-bit BGR format, [23:0] B:G:R little endian
        */
       {
         name: "bgr888",
@@ -667,7 +667,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit xBGR format, [31:0] x:B:G:R 8:8:8:8 little endian
+     * @summary 32-bit xBGR format, [31:0] x:B:G:R 8:8:8:8 little endian
        */
       {
         name: "xbgr8888",
@@ -677,7 +677,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit RGBx format, [31:0] R:G:B:x 8:8:8:8 little endian
+     * @summary 32-bit RGBx format, [31:0] R:G:B:x 8:8:8:8 little endian
        */
       {
         name: "rgbx8888",
@@ -687,7 +687,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit BGRx format, [31:0] B:G:R:x 8:8:8:8 little endian
+     * @summary 32-bit BGRx format, [31:0] B:G:R:x 8:8:8:8 little endian
        */
       {
         name: "bgrx8888",
@@ -697,7 +697,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit ABGR format, [31:0] A:B:G:R 8:8:8:8 little endian
+     * @summary 32-bit ABGR format, [31:0] A:B:G:R 8:8:8:8 little endian
        */
       {
         name: "abgr8888",
@@ -707,7 +707,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit RGBA format, [31:0] R:G:B:A 8:8:8:8 little endian
+     * @summary 32-bit RGBA format, [31:0] R:G:B:A 8:8:8:8 little endian
        */
       {
         name: "rgba8888",
@@ -717,7 +717,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit BGRA format, [31:0] B:G:R:A 8:8:8:8 little endian
+     * @summary 32-bit BGRA format, [31:0] B:G:R:A 8:8:8:8 little endian
        */
       {
         name: "bgra8888",
@@ -727,7 +727,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit xRGB format, [31:0] x:R:G:B 2:10:10:10 little endian
+     * @summary 32-bit xRGB format, [31:0] x:R:G:B 2:10:10:10 little endian
        */
       {
         name: "xrgb2101010",
@@ -737,7 +737,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit xBGR format, [31:0] x:B:G:R 2:10:10:10 little endian
+     * @summary 32-bit xBGR format, [31:0] x:B:G:R 2:10:10:10 little endian
        */
       {
         name: "xbgr2101010",
@@ -747,7 +747,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit RGBx format, [31:0] R:G:B:x 10:10:10:2 little endian
+     * @summary 32-bit RGBx format, [31:0] R:G:B:x 10:10:10:2 little endian
        */
       {
         name: "rgbx1010102",
@@ -757,7 +757,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit BGRx format, [31:0] B:G:R:x 10:10:10:2 little endian
+     * @summary 32-bit BGRx format, [31:0] B:G:R:x 10:10:10:2 little endian
        */
       {
         name: "bgrx1010102",
@@ -767,7 +767,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit ARGB format, [31:0] A:R:G:B 2:10:10:10 little endian
+     * @summary 32-bit ARGB format, [31:0] A:R:G:B 2:10:10:10 little endian
        */
       {
         name: "argb2101010",
@@ -777,7 +777,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit ABGR format, [31:0] A:B:G:R 2:10:10:10 little endian
+     * @summary 32-bit ABGR format, [31:0] A:B:G:R 2:10:10:10 little endian
        */
       {
         name: "abgr2101010",
@@ -787,7 +787,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit RGBA format, [31:0] R:G:B:A 10:10:10:2 little endian
+     * @summary 32-bit RGBA format, [31:0] R:G:B:A 10:10:10:2 little endian
        */
       {
         name: "rgba1010102",
@@ -797,7 +797,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 32-bit BGRA format, [31:0] B:G:R:A 10:10:10:2 little endian
+     * @summary 32-bit BGRA format, [31:0] B:G:R:A 10:10:10:2 little endian
        */
       {
         name: "bgra1010102",
@@ -807,7 +807,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary packed YCbCr format, [31:0] Cr0:Y1:Cb0:Y0 8:8:8:8 little endian
+     * @summary packed YCbCr format, [31:0] Cr0:Y1:Cb0:Y0 8:8:8:8 little endian
        */
       {
         name: "yuyv",
@@ -817,7 +817,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary packed YCbCr format, [31:0] Cb0:Y1:Cr0:Y0 8:8:8:8 little endian
+     * @summary packed YCbCr format, [31:0] Cb0:Y1:Cr0:Y0 8:8:8:8 little endian
        */
       {
         name: "yvyu",
@@ -827,7 +827,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary packed YCbCr format, [31:0] Y1:Cr0:Y0:Cb0 8:8:8:8 little endian
+     * @summary packed YCbCr format, [31:0] Y1:Cr0:Y0:Cb0 8:8:8:8 little endian
        */
       {
         name: "uyvy",
@@ -837,7 +837,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary packed YCbCr format, [31:0] Y1:Cb0:Y0:Cr0 8:8:8:8 little endian
+     * @summary packed YCbCr format, [31:0] Y1:Cb0:Y0:Cr0 8:8:8:8 little endian
        */
       {
         name: "vyuy",
@@ -847,7 +847,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary packed AYCbCr format, [31:0] A:Y:Cb:Cr 8:8:8:8 little endian
+     * @summary packed AYCbCr format, [31:0] A:Y:Cb:Cr 8:8:8:8 little endian
        */
       {
         name: "ayuv",
@@ -857,7 +857,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 2 plane YCbCr Cr:Cb format, 2x2 subsampled Cr:Cb plane
+     * @summary 2 plane YCbCr Cr:Cb format, 2x2 subsampled Cr:Cb plane
        */
       {
         name: "nv12",
@@ -867,7 +867,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 2 plane YCbCr Cb:Cr format, 2x2 subsampled Cb:Cr plane
+     * @summary 2 plane YCbCr Cb:Cr format, 2x2 subsampled Cb:Cr plane
        */
       {
         name: "nv21",
@@ -877,7 +877,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 2 plane YCbCr Cr:Cb format, 2x1 subsampled Cr:Cb plane
+     * @summary 2 plane YCbCr Cr:Cb format, 2x1 subsampled Cr:Cb plane
        */
       {
         name: "nv16",
@@ -887,7 +887,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 2 plane YCbCr Cb:Cr format, 2x1 subsampled Cb:Cr plane
+     * @summary 2 plane YCbCr Cb:Cr format, 2x1 subsampled Cb:Cr plane
        */
       {
         name: "nv61",
@@ -897,7 +897,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 3 plane YCbCr format, 4x4 subsampled Cb (1) and Cr (2) planes
+     * @summary 3 plane YCbCr format, 4x4 subsampled Cb (1) and Cr (2) planes
        */
       {
         name: "yuv410",
@@ -907,7 +907,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 3 plane YCbCr format, 4x4 subsampled Cr (1) and Cb (2) planes
+     * @summary 3 plane YCbCr format, 4x4 subsampled Cr (1) and Cb (2) planes
        */
       {
         name: "yvu410",
@@ -917,7 +917,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 3 plane YCbCr format, 4x1 subsampled Cb (1) and Cr (2) planes
+     * @summary 3 plane YCbCr format, 4x1 subsampled Cb (1) and Cr (2) planes
        */
       {
         name: "yuv411",
@@ -927,7 +927,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 3 plane YCbCr format, 4x1 subsampled Cr (1) and Cb (2) planes
+     * @summary 3 plane YCbCr format, 4x1 subsampled Cr (1) and Cb (2) planes
        */
       {
         name: "yvu411",
@@ -937,7 +937,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 3 plane YCbCr format, 2x2 subsampled Cb (1) and Cr (2) planes
+     * @summary 3 plane YCbCr format, 2x2 subsampled Cb (1) and Cr (2) planes
        */
       {
         name: "yuv420",
@@ -947,7 +947,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 3 plane YCbCr format, 2x2 subsampled Cr (1) and Cb (2) planes
+     * @summary 3 plane YCbCr format, 2x2 subsampled Cr (1) and Cb (2) planes
        */
       {
         name: "yvu420",
@@ -957,7 +957,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 3 plane YCbCr format, 2x1 subsampled Cb (1) and Cr (2) planes
+     * @summary 3 plane YCbCr format, 2x1 subsampled Cb (1) and Cr (2) planes
        */
       {
         name: "yuv422",
@@ -967,7 +967,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 3 plane YCbCr format, 2x1 subsampled Cr (1) and Cb (2) planes
+     * @summary 3 plane YCbCr format, 2x1 subsampled Cr (1) and Cb (2) planes
        */
       {
         name: "yvu422",
@@ -977,7 +977,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 3 plane YCbCr format, non-subsampled Cb (1) and Cr (2) planes
+     * @summary 3 plane YCbCr format, non-subsampled Cb (1) and Cr (2) planes
        */
       {
         name: "yuv444",
@@ -987,7 +987,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 3 plane YCbCr format, non-subsampled Cr (1) and Cb (2) planes
+     * @summary 3 plane YCbCr format, non-subsampled Cr (1) and Cb (2) planes
        */
       {
         name: "yvu444",
@@ -997,7 +997,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [7:0] R
+     * @summary [7:0] R
        */
       {
         name: "r8",
@@ -1007,7 +1007,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [15:0] R little endian
+     * @summary [15:0] R little endian
        */
       {
         name: "r16",
@@ -1017,7 +1017,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [15:0] R:G 8:8 little endian
+     * @summary [15:0] R:G 8:8 little endian
        */
       {
         name: "rg88",
@@ -1027,7 +1027,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [15:0] G:R 8:8 little endian
+     * @summary [15:0] G:R 8:8 little endian
        */
       {
         name: "gr88",
@@ -1037,7 +1037,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [31:0] R:G 16:16 little endian
+     * @summary [31:0] R:G 16:16 little endian
        */
       {
         name: "rg1616",
@@ -1047,7 +1047,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [31:0] G:R 16:16 little endian
+     * @summary [31:0] G:R 16:16 little endian
        */
       {
         name: "gr1616",
@@ -1057,7 +1057,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0] x:R:G:B 16:16:16:16 little endian
+     * @summary [63:0] x:R:G:B 16:16:16:16 little endian
        */
       {
         name: "xrgb16161616f",
@@ -1067,7 +1067,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0] x:B:G:R 16:16:16:16 little endian
+     * @summary [63:0] x:B:G:R 16:16:16:16 little endian
        */
       {
         name: "xbgr16161616f",
@@ -1077,7 +1077,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0] A:R:G:B 16:16:16:16 little endian
+     * @summary [63:0] A:R:G:B 16:16:16:16 little endian
        */
       {
         name: "argb16161616f",
@@ -1087,7 +1087,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0] A:B:G:R 16:16:16:16 little endian
+     * @summary [63:0] A:B:G:R 16:16:16:16 little endian
        */
       {
         name: "abgr16161616f",
@@ -1097,7 +1097,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [31:0] X:Y:Cb:Cr 8:8:8:8 little endian
+     * @summary [31:0] X:Y:Cb:Cr 8:8:8:8 little endian
        */
       {
         name: "xyuv8888",
@@ -1107,7 +1107,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [23:0] Cr:Cb:Y 8:8:8 little endian
+     * @summary [23:0] Cr:Cb:Y 8:8:8 little endian
        */
       {
         name: "vuy888",
@@ -1117,7 +1117,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary Y followed by U then V, 10:10:10. Non-linear modifier only
+     * @summary Y followed by U then V, 10:10:10. Non-linear modifier only
        */
       {
         name: "vuy101010",
@@ -1127,7 +1127,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0] Cr0:0:Y1:0:Cb0:0:Y0:0 10:6:10:6:10:6:10:6 little endian per 2 Y pixels
+     * @summary [63:0] Cr0:0:Y1:0:Cb0:0:Y0:0 10:6:10:6:10:6:10:6 little endian per 2 Y pixels
        */
       {
         name: "y210",
@@ -1137,7 +1137,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0] Cr0:0:Y1:0:Cb0:0:Y0:0 12:4:12:4:12:4:12:4 little endian per 2 Y pixels
+     * @summary [63:0] Cr0:0:Y1:0:Cb0:0:Y0:0 12:4:12:4:12:4:12:4 little endian per 2 Y pixels
        */
       {
         name: "y212",
@@ -1147,7 +1147,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0] Cr0:Y1:Cb0:Y0 16:16:16:16 little endian per 2 Y pixels
+     * @summary [63:0] Cr0:Y1:Cb0:Y0 16:16:16:16 little endian per 2 Y pixels
        */
       {
         name: "y216",
@@ -1157,7 +1157,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [31:0] A:Cr:Y:Cb 2:10:10:10 little endian
+     * @summary [31:0] A:Cr:Y:Cb 2:10:10:10 little endian
        */
       {
         name: "y410",
@@ -1167,7 +1167,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0] A:0:Cr:0:Y:0:Cb:0 12:4:12:4:12:4:12:4 little endian
+     * @summary [63:0] A:0:Cr:0:Y:0:Cb:0 12:4:12:4:12:4:12:4 little endian
        */
       {
         name: "y412",
@@ -1177,7 +1177,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0] A:Cr:Y:Cb 16:16:16:16 little endian
+     * @summary [63:0] A:Cr:Y:Cb 16:16:16:16 little endian
        */
       {
         name: "y416",
@@ -1187,7 +1187,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [31:0] X:Cr:Y:Cb 2:10:10:10 little endian
+     * @summary [31:0] X:Cr:Y:Cb 2:10:10:10 little endian
        */
       {
         name: "xvyu2101010",
@@ -1197,7 +1197,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0] X:0:Cr:0:Y:0:Cb:0 12:4:12:4:12:4:12:4 little endian
+     * @summary [63:0] X:0:Cr:0:Y:0:Cb:0 12:4:12:4:12:4:12:4 little endian
        */
       {
         name: "xvyu12_16161616",
@@ -1207,7 +1207,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0] X:Cr:Y:Cb 16:16:16:16 little endian
+     * @summary [63:0] X:Cr:Y:Cb 16:16:16:16 little endian
        */
       {
         name: "xvyu16161616",
@@ -1217,7 +1217,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0]   A3:A2:Y3:0:Cr0:0:Y2:0:A1:A0:Y1:0:Cb0:0:Y0:0  1:1:8:2:8:2:8:2:1:1:8:2:8:2:8:2 little endian
+     * @summary [63:0]   A3:A2:Y3:0:Cr0:0:Y2:0:A1:A0:Y1:0:Cb0:0:Y0:0  1:1:8:2:8:2:8:2:1:1:8:2:8:2:8:2 little endian
        */
       {
         name: "y0l0",
@@ -1227,7 +1227,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0]   X3:X2:Y3:0:Cr0:0:Y2:0:X1:X0:Y1:0:Cb0:0:Y0:0  1:1:8:2:8:2:8:2:1:1:8:2:8:2:8:2 little endian
+     * @summary [63:0]   X3:X2:Y3:0:Cr0:0:Y2:0:X1:X0:Y1:0:Cb0:0:Y0:0  1:1:8:2:8:2:8:2:1:1:8:2:8:2:8:2 little endian
        */
       {
         name: "x0l0",
@@ -1237,7 +1237,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0]   A3:A2:Y3:Cr0:Y2:A1:A0:Y1:Cb0:Y0  1:1:10:10:10:1:1:10:10:10 little endian
+     * @summary [63:0]   A3:A2:Y3:Cr0:Y2:A1:A0:Y1:Cb0:Y0  1:1:10:10:10:1:1:10:10:10 little endian
        */
       {
         name: "y0l2",
@@ -1247,7 +1247,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0]   X3:X2:Y3:Cr0:Y2:X1:X0:Y1:Cb0:Y0  1:1:10:10:10:1:1:10:10:10 little endian
+     * @summary [63:0]   X3:X2:Y3:Cr0:Y2:X1:X0:Y1:Cb0:Y0  1:1:10:10:10:1:1:10:10:10 little endian
        */
       {
         name: "x0l2",
@@ -1257,107 +1257,97 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       *
        */
       {
         name: "yuv420_8bit",
         value: 942691673,
-        summary: "undefined",
+        summary: "",
       },
     
     
       /**
-       *
        */
       {
         name: "yuv420_10bit",
         value: 808539481,
-        summary: "undefined",
+        summary: "",
       },
     
     
       /**
-       *
        */
       {
         name: "xrgb8888_a8",
         value: 943805016,
-        summary: "undefined",
+        summary: "",
       },
     
     
       /**
-       *
        */
       {
         name: "xbgr8888_a8",
         value: 943800920,
-        summary: "undefined",
+        summary: "",
       },
     
     
       /**
-       *
        */
       {
         name: "rgbx8888_a8",
         value: 943806546,
-        summary: "undefined",
+        summary: "",
       },
     
     
       /**
-       *
        */
       {
         name: "bgrx8888_a8",
         value: 943806530,
-        summary: "undefined",
+        summary: "",
       },
     
     
       /**
-       *
        */
       {
         name: "rgb888_a8",
         value: 943798354,
-        summary: "undefined",
+        summary: "",
       },
     
     
       /**
-       *
        */
       {
         name: "bgr888_a8",
         value: 943798338,
-        summary: "undefined",
+        summary: "",
       },
     
     
       /**
-       *
        */
       {
         name: "rgb565_a8",
         value: 943797586,
-        summary: "undefined",
+        summary: "",
       },
     
     
       /**
-       *
        */
       {
         name: "bgr565_a8",
         value: 943797570,
-        summary: "undefined",
+        summary: "",
       },
     
     
       /**
-       * @summary non-subsampled Cr:Cb plane
+     * @summary non-subsampled Cr:Cb plane
        */
       {
         name: "nv24",
@@ -1367,7 +1357,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary non-subsampled Cb:Cr plane
+     * @summary non-subsampled Cb:Cr plane
        */
       {
         name: "nv42",
@@ -1377,7 +1367,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 2x1 subsampled Cr:Cb plane, 10 bit per channel
+     * @summary 2x1 subsampled Cr:Cb plane, 10 bit per channel
        */
       {
         name: "p210",
@@ -1387,7 +1377,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 2x2 subsampled Cr:Cb plane 10 bits per channel
+     * @summary 2x2 subsampled Cr:Cb plane 10 bits per channel
        */
       {
         name: "p010",
@@ -1397,7 +1387,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 2x2 subsampled Cr:Cb plane 12 bits per channel
+     * @summary 2x2 subsampled Cr:Cb plane 12 bits per channel
        */
       {
         name: "p012",
@@ -1407,7 +1397,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 2x2 subsampled Cr:Cb plane 16 bits per channel
+     * @summary 2x2 subsampled Cr:Cb plane 16 bits per channel
        */
       {
         name: "p016",
@@ -1417,7 +1407,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary [63:0] A:x:B:x:G:x:R:x 10:6:10:6:10:6:10:6 little endian
+     * @summary [63:0] A:x:B:x:G:x:R:x 10:6:10:6:10:6:10:6 little endian
        */
       {
         name: "axbxgxrx106106106106",
@@ -1427,7 +1417,7 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       * @summary 2x2 subsampled Cr:Cb plane
+     * @summary 2x2 subsampled Cr:Cb plane
        */
       {
         name: "nv15",
@@ -1437,22 +1427,20 @@ export interface Wl_shm extends Wl_interface{
     
     
       /**
-       *
        */
       {
         name: "q410",
         value: 808531025,
-        summary: "undefined",
+        summary: "",
       },
     
     
       /**
-       *
        */
       {
         name: "q401",
         value: 825242705,
-        summary: "undefined",
+        summary: "",
       },
     
     ]
@@ -1562,7 +1550,7 @@ export interface Wl_data_offer extends Wl_interface{
     error: [
       
       /**
-       * @summary finish request was called untimely
+     * @summary finish request was called untimely
        */
       {
         name: "invalid_finish",
@@ -1572,7 +1560,7 @@ export interface Wl_data_offer extends Wl_interface{
     
     
       /**
-       * @summary action mask contains invalid values
+     * @summary action mask contains invalid values
        */
       {
         name: "invalid_action_mask",
@@ -1582,7 +1570,7 @@ export interface Wl_data_offer extends Wl_interface{
     
     
       /**
-       * @summary action argument has an invalid value
+     * @summary action argument has an invalid value
        */
       {
         name: "invalid_action",
@@ -1592,7 +1580,7 @@ export interface Wl_data_offer extends Wl_interface{
     
     
       /**
-       * @summary offer doesn't accept this request
+     * @summary offer doesn't accept this request
        */
       {
         name: "invalid_offer",
@@ -1816,7 +1804,7 @@ export interface Wl_data_source extends Wl_interface{
     error: [
       
       /**
-       * @summary action mask contains invalid values
+     * @summary action mask contains invalid values
        */
       {
         name: "invalid_action_mask",
@@ -1826,7 +1814,7 @@ export interface Wl_data_source extends Wl_interface{
     
     
       /**
-       * @summary source doesn't accept this request
+     * @summary source doesn't accept this request
        */
       {
         name: "invalid_source",
@@ -2021,7 +2009,7 @@ export interface Wl_data_device extends Wl_interface{
     error: [
       
       /**
-       * @summary given wl_surface has another role
+     * @summary given wl_surface has another role
        */
       {
         name: "role",
@@ -2216,7 +2204,7 @@ export interface Wl_data_device_manager extends Wl_interface{
     dnd_action: [
       
       /**
-       * @summary no action
+     * @summary no action
        */
       {
         name: "none",
@@ -2226,7 +2214,7 @@ export interface Wl_data_device_manager extends Wl_interface{
     
     
       /**
-       * @summary copy action
+     * @summary copy action
        */
       {
         name: "copy",
@@ -2236,7 +2224,7 @@ export interface Wl_data_device_manager extends Wl_interface{
     
     
       /**
-       * @summary move action
+     * @summary move action
        */
       {
         name: "move",
@@ -2246,7 +2234,7 @@ export interface Wl_data_device_manager extends Wl_interface{
     
     
       /**
-       * @summary ask action
+     * @summary ask action
        */
       {
         name: "ask",
@@ -2305,7 +2293,7 @@ export interface Wl_shell extends Wl_interface{
     error: [
       
       /**
-       * @summary given wl_surface has another role
+     * @summary given wl_surface has another role
        */
       {
         name: "role",
@@ -2360,7 +2348,7 @@ export interface Wl_shell_surface extends Wl_interface{
     resize: [
       
       /**
-       * @summary no edge
+     * @summary no edge
        */
       {
         name: "none",
@@ -2370,7 +2358,7 @@ export interface Wl_shell_surface extends Wl_interface{
     
     
       /**
-       * @summary top edge
+     * @summary top edge
        */
       {
         name: "top",
@@ -2380,7 +2368,7 @@ export interface Wl_shell_surface extends Wl_interface{
     
     
       /**
-       * @summary bottom edge
+     * @summary bottom edge
        */
       {
         name: "bottom",
@@ -2390,7 +2378,7 @@ export interface Wl_shell_surface extends Wl_interface{
     
     
       /**
-       * @summary left edge
+     * @summary left edge
        */
       {
         name: "left",
@@ -2400,7 +2388,7 @@ export interface Wl_shell_surface extends Wl_interface{
     
     
       /**
-       * @summary top and left edges
+     * @summary top and left edges
        */
       {
         name: "top_left",
@@ -2410,7 +2398,7 @@ export interface Wl_shell_surface extends Wl_interface{
     
     
       /**
-       * @summary bottom and left edges
+     * @summary bottom and left edges
        */
       {
         name: "bottom_left",
@@ -2420,7 +2408,7 @@ export interface Wl_shell_surface extends Wl_interface{
     
     
       /**
-       * @summary right edge
+     * @summary right edge
        */
       {
         name: "right",
@@ -2430,7 +2418,7 @@ export interface Wl_shell_surface extends Wl_interface{
     
     
       /**
-       * @summary top and right edges
+     * @summary top and right edges
        */
       {
         name: "top_right",
@@ -2440,7 +2428,7 @@ export interface Wl_shell_surface extends Wl_interface{
     
     
       /**
-       * @summary bottom and right edges
+     * @summary bottom and right edges
        */
       {
         name: "bottom_right",
@@ -2454,7 +2442,7 @@ export interface Wl_shell_surface extends Wl_interface{
     transient: [
       
       /**
-       * @summary do not set keyboard focus
+     * @summary do not set keyboard focus
        */
       {
         name: "inactive",
@@ -2468,7 +2456,7 @@ export interface Wl_shell_surface extends Wl_interface{
     fullscreen_method: [
       
       /**
-       * @summary no preference, apply default policy
+     * @summary no preference, apply default policy
        */
       {
         name: "default",
@@ -2478,7 +2466,7 @@ export interface Wl_shell_surface extends Wl_interface{
     
     
       /**
-       * @summary scale, preserve the surface's aspect ratio and center on output
+     * @summary scale, preserve the surface's aspect ratio and center on output
        */
       {
         name: "scale",
@@ -2488,7 +2476,7 @@ export interface Wl_shell_surface extends Wl_interface{
     
     
       /**
-       * @summary switch output mode to the smallest mode that can fit the surface, add black borders to compensate size mismatch
+     * @summary switch output mode to the smallest mode that can fit the surface, add black borders to compensate size mismatch
        */
       {
         name: "driver",
@@ -2498,7 +2486,7 @@ export interface Wl_shell_surface extends Wl_interface{
     
     
       /**
-       * @summary no upscaling, center on output and add black borders to compensate size mismatch
+     * @summary no upscaling, center on output and add black borders to compensate size mismatch
        */
       {
         name: "fill",
@@ -2831,7 +2819,7 @@ export interface Wl_surface extends Wl_interface{
     error: [
       
       /**
-       * @summary buffer scale value is invalid
+     * @summary buffer scale value is invalid
        */
       {
         name: "invalid_scale",
@@ -2841,7 +2829,7 @@ export interface Wl_surface extends Wl_interface{
     
     
       /**
-       * @summary buffer transform value is invalid
+     * @summary buffer transform value is invalid
        */
       {
         name: "invalid_transform",
@@ -2851,7 +2839,7 @@ export interface Wl_surface extends Wl_interface{
     
     
       /**
-       * @summary buffer size is invalid
+     * @summary buffer size is invalid
        */
       {
         name: "invalid_size",
@@ -3268,7 +3256,7 @@ export interface Wl_seat extends Wl_interface{
     capability: [
       
       /**
-       * @summary the seat has pointer devices
+     * @summary the seat has pointer devices
        */
       {
         name: "pointer",
@@ -3278,7 +3266,7 @@ export interface Wl_seat extends Wl_interface{
     
     
       /**
-       * @summary the seat has one or more keyboards
+     * @summary the seat has one or more keyboards
        */
       {
         name: "keyboard",
@@ -3288,7 +3276,7 @@ export interface Wl_seat extends Wl_interface{
     
     
       /**
-       * @summary the seat has touch devices
+     * @summary the seat has touch devices
        */
       {
         name: "touch",
@@ -3302,7 +3290,7 @@ export interface Wl_seat extends Wl_interface{
     error: [
       
       /**
-       * @summary get_pointer, get_keyboard or get_touch called on seat without the matching capability
+     * @summary get_pointer, get_keyboard or get_touch called on seat without the matching capability
        */
       {
         name: "missing_capability",
@@ -3447,7 +3435,7 @@ export interface Wl_pointer extends Wl_interface{
     error: [
       
       /**
-       * @summary given wl_surface has another role
+     * @summary given wl_surface has another role
        */
       {
         name: "role",
@@ -3461,7 +3449,7 @@ export interface Wl_pointer extends Wl_interface{
     button_state: [
       
       /**
-       * @summary the button is not pressed
+     * @summary the button is not pressed
        */
       {
         name: "released",
@@ -3471,7 +3459,7 @@ export interface Wl_pointer extends Wl_interface{
     
     
       /**
-       * @summary the button is pressed
+     * @summary the button is pressed
        */
       {
         name: "pressed",
@@ -3485,7 +3473,7 @@ export interface Wl_pointer extends Wl_interface{
     axis: [
       
       /**
-       * @summary vertical axis
+     * @summary vertical axis
        */
       {
         name: "vertical_scroll",
@@ -3495,7 +3483,7 @@ export interface Wl_pointer extends Wl_interface{
     
     
       /**
-       * @summary horizontal axis
+     * @summary horizontal axis
        */
       {
         name: "horizontal_scroll",
@@ -3509,7 +3497,7 @@ export interface Wl_pointer extends Wl_interface{
     axis_source: [
       
       /**
-       * @summary a physical wheel rotation
+     * @summary a physical wheel rotation
        */
       {
         name: "wheel",
@@ -3519,7 +3507,7 @@ export interface Wl_pointer extends Wl_interface{
     
     
       /**
-       * @summary finger on a touch surface
+     * @summary finger on a touch surface
        */
       {
         name: "finger",
@@ -3529,7 +3517,7 @@ export interface Wl_pointer extends Wl_interface{
     
     
       /**
-       * @summary continuous coordinate space
+     * @summary continuous coordinate space
        */
       {
         name: "continuous",
@@ -3539,7 +3527,7 @@ export interface Wl_pointer extends Wl_interface{
     
     
       /**
-       * @summary a physical wheel tilt
+     * @summary a physical wheel tilt
        */
       {
         name: "wheel_tilt",
@@ -3843,7 +3831,7 @@ export interface Wl_keyboard extends Wl_interface{
     keymap_format: [
       
       /**
-       * @summary no keymap; client must understand how to interpret the raw keycode
+     * @summary no keymap; client must understand how to interpret the raw keycode
        */
       {
         name: "no_keymap",
@@ -3853,7 +3841,7 @@ export interface Wl_keyboard extends Wl_interface{
     
     
       /**
-       * @summary libxkbcommon compatible; to determine the xkb keycode, clients must add 8 to the key event keycode
+     * @summary libxkbcommon compatible; to determine the xkb keycode, clients must add 8 to the key event keycode
        */
       {
         name: "xkb_v1",
@@ -3867,7 +3855,7 @@ export interface Wl_keyboard extends Wl_interface{
     key_state: [
       
       /**
-       * @summary key is not pressed
+     * @summary key is not pressed
        */
       {
         name: "released",
@@ -3877,7 +3865,7 @@ export interface Wl_keyboard extends Wl_interface{
     
     
       /**
-       * @summary key is pressed
+     * @summary key is pressed
        */
       {
         name: "pressed",
@@ -4167,7 +4155,7 @@ export interface Wl_output extends Wl_interface{
     subpixel: [
       
       /**
-       * @summary unknown geometry
+     * @summary unknown geometry
        */
       {
         name: "unknown",
@@ -4177,7 +4165,7 @@ export interface Wl_output extends Wl_interface{
     
     
       /**
-       * @summary no geometry
+     * @summary no geometry
        */
       {
         name: "none",
@@ -4187,7 +4175,7 @@ export interface Wl_output extends Wl_interface{
     
     
       /**
-       * @summary horizontal RGB
+     * @summary horizontal RGB
        */
       {
         name: "horizontal_rgb",
@@ -4197,7 +4185,7 @@ export interface Wl_output extends Wl_interface{
     
     
       /**
-       * @summary horizontal BGR
+     * @summary horizontal BGR
        */
       {
         name: "horizontal_bgr",
@@ -4207,7 +4195,7 @@ export interface Wl_output extends Wl_interface{
     
     
       /**
-       * @summary vertical RGB
+     * @summary vertical RGB
        */
       {
         name: "vertical_rgb",
@@ -4217,7 +4205,7 @@ export interface Wl_output extends Wl_interface{
     
     
       /**
-       * @summary vertical BGR
+     * @summary vertical BGR
        */
       {
         name: "vertical_bgr",
@@ -4231,7 +4219,7 @@ export interface Wl_output extends Wl_interface{
     transform: [
       
       /**
-       * @summary no transform
+     * @summary no transform
        */
       {
         name: "normal",
@@ -4241,7 +4229,7 @@ export interface Wl_output extends Wl_interface{
     
     
       /**
-       * @summary 90 degrees counter-clockwise
+     * @summary 90 degrees counter-clockwise
        */
       {
         name: "90",
@@ -4251,7 +4239,7 @@ export interface Wl_output extends Wl_interface{
     
     
       /**
-       * @summary 180 degrees counter-clockwise
+     * @summary 180 degrees counter-clockwise
        */
       {
         name: "180",
@@ -4261,7 +4249,7 @@ export interface Wl_output extends Wl_interface{
     
     
       /**
-       * @summary 270 degrees counter-clockwise
+     * @summary 270 degrees counter-clockwise
        */
       {
         name: "270",
@@ -4271,7 +4259,7 @@ export interface Wl_output extends Wl_interface{
     
     
       /**
-       * @summary 180 degree flip around a vertical axis
+     * @summary 180 degree flip around a vertical axis
        */
       {
         name: "flipped",
@@ -4281,7 +4269,7 @@ export interface Wl_output extends Wl_interface{
     
     
       /**
-       * @summary flip and rotate 90 degrees counter-clockwise
+     * @summary flip and rotate 90 degrees counter-clockwise
        */
       {
         name: "flipped_90",
@@ -4291,7 +4279,7 @@ export interface Wl_output extends Wl_interface{
     
     
       /**
-       * @summary flip and rotate 180 degrees counter-clockwise
+     * @summary flip and rotate 180 degrees counter-clockwise
        */
       {
         name: "flipped_180",
@@ -4301,7 +4289,7 @@ export interface Wl_output extends Wl_interface{
     
     
       /**
-       * @summary flip and rotate 270 degrees counter-clockwise
+     * @summary flip and rotate 270 degrees counter-clockwise
        */
       {
         name: "flipped_270",
@@ -4315,7 +4303,7 @@ export interface Wl_output extends Wl_interface{
     mode: [
       
       /**
-       * @summary indicates this is the current mode
+     * @summary indicates this is the current mode
        */
       {
         name: "current",
@@ -4325,7 +4313,7 @@ export interface Wl_output extends Wl_interface{
     
     
       /**
-       * @summary indicates this is the preferred mode
+     * @summary indicates this is the preferred mode
        */
       {
         name: "preferred",
@@ -4541,7 +4529,7 @@ export interface Wl_subcompositor extends Wl_interface{
     error: [
       
       /**
-       * @summary the to-be sub-surface is invalid
+     * @summary the to-be sub-surface is invalid
        */
       {
         name: "bad_surface",
@@ -4658,7 +4646,7 @@ export interface Wl_subsurface extends Wl_interface{
     error: [
       
       /**
-       * @summary wl_surface is not a sibling or the parent
+     * @summary wl_surface is not a sibling or the parent
        */
       {
         name: "bad_surface",


### PR DESCRIPTION
wl_fixed_t is a two's-complement int32 holding value*256, not a
sign-magnitude number. The previous writeFixed/readFixed set bit 31 as a
sign flag and stored the magnitude separately, which corrupted every
negative fixed-point value on the wire (e.g. -1.0 was encoded as
0x80000100, which a real compositor decodes as -8388607.0; the correct
wire word is 0xFFFFFF00).

Encode as the plain int32 round(value*256) and decode as int32/256,
matching the reference wl_fixed_from_double()/wl_fixed_to_double() in
wayland-util.h.

The existing regression test asserted the buggy 0x80000100 == -1.0
mapping; correct it to 0xFFFFFF00 and add -1.5/0.5/-0.5 round-trips.